### PR TITLE
Update docker for new structure of dea-proto

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,17 +1,18 @@
 FROM opendatacube/wms:latest
 
-# Ensure compatible versions of boto are installed
-RUN pip3 uninstall boto3 botocore dea-proto -y && \
-    pip3 install -U 'aiobotocore[awscli,boto3]' google-cloud-storage
-
-# Install dea proto for indexing tools
-RUN pip3 install -e 'git+https://github.com/opendatacube/dea-proto.git#egg=project[GCP,THREDDS]'
-
 # Install C version of PyYaml
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libyaml-dev \
-    && rm -rf /var/lib/apt/lists/* && \
-    pip3 --no-cache-dir install --verbose --force-reinstall -I pyyaml
+  libyaml-dev \
+  && rm -rf /var/lib/apt/lists/* && \
+  pip3 --no-cache-dir install --verbose --force-reinstall -I pyyaml
+
+# Ensure compatible versions of boto are installed
+RUN pip3 --no-cache-dir install -U 'aiobotocore[awscli,boto3]' google-cloud-storage
+
+# Install dea proto for indexing tools
+RUN pip3 --no-cache-dir install 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_apps_cloud[GCP,THREDDS]&subdirectory=apps/cloud' && \
+    pip3 --no-cache-dir install 'git+https://github.com/opendatacube/dea-proto.git#egg=odc_apps_dc_tools&subdirectory=apps/dc_tools'
+
 
 COPY assets/update_ranges.sh /code/index/indexing/update_ranges.sh
 COPY assets/update_ranges_wrapper.sh /code/index/indexing/update_ranges_wrapper.sh


### PR DESCRIPTION
CLI tools need to be installed separately now.

NOTE: this assumes that `opendatacube/wms:latest` comes with upgraded version of
`pip`.