### PR TITLE
Add and update error handling for STAC API to DC

### DIFF
--- a/odc_index/stac_api_to_dc.py
+++ b/odc_index/stac_api_to_dc.py
@@ -67,7 +67,7 @@ def transform_items(
                 metadata = stac_transform_absolute(metadata)
         except KeyError as e:
             logging.error(f"Failed to handle item with KeyError: '{e}'\n The URI was {uri}")
-            yield None, None
+            yield None, uri
             continue
 
         try:
@@ -78,7 +78,7 @@ def transform_items(
             yield ds, uri
         else:
             logging.error(f"Failed to create dataset with error {err}\n The URI was {uri}")
-            yield None, None
+            yield None, uri
 
 
 def index_update_datasets(

--- a/odc_index/stac_api_to_dc.py
+++ b/odc_index/stac_api_to_dc.py
@@ -66,13 +66,18 @@ def transform_items(
             else:
                 metadata = stac_transform_absolute(metadata)
         except KeyError as e:
-            logging.error(f"Failed to handle item at {uri} with error {e}")
+            logging.error(f"Failed to handle item with KeyError: '{e}'\n The URI was {uri}")
             yield None, None
-        ds, err = doc2ds(metadata, uri)
+            continue
+
+        try:
+            ds, err = doc2ds(metadata, uri)
+        except ValueError as e:
+            logging.error(f"Exception thrown when trying to create dataset: '{e}'\n The URI was {uri}")
         if ds is not None:
             yield ds, uri
         else:
-            logging.error(f"Failed to create dataset with error {err}")
+            logging.error(f"Failed to create dataset with error {err}\n The URI was {uri}")
             yield None, None
 
 
@@ -208,7 +213,7 @@ def cli(
         dc, candidate_products, limit, update, allow_unsafe, config
     )
 
-    print(f"Added {added} Datasets, Failed {failed} Datasets")
+    print(f"Added {added} Datasets, failed {failed} Datasets")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Logic issue where the author didn't realise that `yield` was not the same as `return` and yield was being called twice
- Handle errors better including better messages about what has failed