### PR TITLE
Update odc-index version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ These utilities include:
 #. **s3-to-dc**: Index from S3 storage to a Datacube database.
 #. **thredds-to-dc**: Index from Thredds server to a Datacube database.
 #. **sqs-to-dc**: Index from SQS queue to a Datacube database.
-#. **stac-to-dc**: Index from a STAC API into a Dacube database.
+#. **stac-to-dc**: Index from a STAC API into a Datacube database.
 
 It has code to perform the follow steps:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - AWS_DEFAULT_REGION=ap-southeast-2
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - STAC_API_URL=https://earth-search.aws.element84.com/v0/
     depends_on:
       - dc-db
     command: tail -f /dev/null

--- a/odc_index/requirements.txt
+++ b/odc_index/requirements.txt
@@ -9,6 +9,6 @@ odc-aws
 odc-aio
 odc-thredds
 odc-apps-cloud
-# Pinned for Alex to index STAC
-sat-search==0.3.0-rc1
 odc-index
+# Pinned for Alex to index STAC
+sat-search==0.3.0

--- a/odc_index/requirements.txt
+++ b/odc_index/requirements.txt
@@ -11,4 +11,4 @@ odc-thredds
 odc-apps-cloud
 # Pinned for Alex to index STAC
 sat-search==0.3.0-rc1
-odc-index==0.1.dev582+ge663766
+odc-index

--- a/odc_index/requirements.txt
+++ b/odc_index/requirements.txt
@@ -11,4 +11,4 @@ odc-thredds
 odc-apps-cloud
 # Pinned for Alex to index STAC
 sat-search==0.3.0-rc1
-odc-index==0.1.dev573+ge694e61
+odc-index==0.1.dev582+ge663766


### PR DESCRIPTION
Updated `odc-index` to `0.1.dev582+ge663766` to use stac_transform. Should we unpin the version?