### PR TITLE
Add product name to doc2dataset

### DIFF
--- a/odc_index/sqs_to_dc.py
+++ b/odc_index/sqs_to_dc.py
@@ -57,7 +57,7 @@ def queue_to_odc(
     ds_success = 0
     ds_failed = 0
 
-    doc2ds = Doc2Dataset(dc.index, **kwargs)
+    doc2ds = Doc2Dataset(dc.index, products, **kwargs)
 
     messages = get_messages(queue, limit)
     for message in messages:

--- a/odc_index/sqs_to_dc.py
+++ b/odc_index/sqs_to_dc.py
@@ -57,7 +57,7 @@ def queue_to_odc(
     ds_success = 0
     ds_failed = 0
 
-    doc2ds = Doc2Dataset(dc.index, products, **kwargs)
+    doc2ds = Doc2Dataset(dc.index, products=products, **kwargs)
 
     messages = get_messages(queue, limit)
     for message in messages:


### PR DESCRIPTION
sqs-to-dc isnt enforcing product name
```
[2020-09-08 06:54:25,955] {{pod_launcher.py:141}} INFO - Event: datacube-index-5bf0e50ab0654a13a328e4227c05656d had an event of type Pending
[2020-09-08 06:54:26,963] {{pod_launcher.py:141}} INFO - Event: datacube-index-5bf0e50ab0654a13a328e4227c05656d had an event of type Pending
[2020-09-08 06:54:27,971] {{pod_launcher.py:141}} INFO - Event: datacube-index-5bf0e50ab0654a13a328e4227c05656d had an event of type Running
[2020-09-08 06:54:29,322] {{pod_launcher.py:124}} INFO - b'/env/lib/python3.6/site-packages/odc_index/sqs_to_dc.py:174: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n'
[2020-09-08 06:54:29,323] {{pod_launcher.py:124}} INFO - b'  data = load(obj["Body"].read())\n'
[2020-09-08 06:54:29,323] {{pod_launcher.py:124}} INFO - b'ERROR:root:Failed to create dataset with error Auto match failed, dataset 44331904-f058-4fc6-9762-39c2dbaeefbd matches several products:\n'
[2020-09-08 06:54:29,323] {{pod_launcher.py:124}} INFO - b'  s2b_msiard_nrt_granule,s2b_nrt_granule\n'
[2020-09-08 06:54:29,323] {{pod_launcher.py:124}} INFO - b' The URI was http://dea-public-data.s3.amazonaws.com/L2/sentinel-2-nrt/S2MSIARD/2020-09-04/S2B_OPER_MSI_ARD_TL_EPAE_20200904T012450_A018260_T56LQP_N02.09/ARD-METADATA.yaml\n'
[2020-09-08 06:54:29,518] {{pod_launcher.py:124}} INFO - b'ERROR:root:Failed to create dataset with error Auto match failed, dataset cd82d6aa-1b8e-4965-89dd-9dbb231891f0 matches several products:\n'
[2020-09-08 06:54:29,518] {{pod_launcher.py:124}} INFO - b'  s2b_msiard_nrt_granule,s2b_nrt_granule\n'
[2020-09-08 06:54:29,518] {{pod_launcher.py:124}} INFO - b' The URI was http://dea-public-data.s3.amazonaws.com/L2/sentinel-2-nrt/S2MSIARD/2020-09-04/S2B_OPER_MSI_ARD_TL_EPAE_20200904T012450_A018260_T56LLN_N02.09/ARD-METADATA.yaml\n'
[2020-09-08 06:54:29,540] {{pod_launcher.py:124}} INFO - b'Added 0 Dataset(s), Failed 2 Dataset(s)\n'
```

the script
```
INDEXING_BASH_COMMAND = [
    "bash",
    "-c",
    dedent(
        """
        for product in %s; do
            sqs-to-dc %s $product --skip-lineage --allow-unsafe --record-path "L2/sentinel-2-nrt/S2MSIARD/*/*/ARD-METADATA.yaml" --limit 1;
        done;
    """
    )
    % (INDEXING_PRODUCTS, SQS_QUEUE_NAME),
]