### PR TITLE
Added tests for stac transform

### DIFF
--- a/tests/test_sqs_to_dc.py
+++ b/tests/test_sqs_to_dc.py
@@ -12,13 +12,13 @@ from pathlib import Path
 from datacube.utils import documents
 from deepdiff import DeepDiff
 from datetime import date
+from odc.index.stac import stac_transform
 from odc_index.sqs_to_dc import (
     get_metadata_uri,
     get_metadata_from_s3_record,
     get_s3_url,
 )
 
-# from odc.index.stac import stac_transform
 
 TEST_DATA_FOLDER: Path = Path(__file__).parent.joinpath("data")
 LANDSAT_C3_SQS_MESSAGE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
@@ -87,53 +87,56 @@ def test_odc_metadata_link(ga_ls8c_ard_3_message):
     )
 
 
-# TODO: Following tests will require updated package of odc_index.stac.stac_transform
-# def test_stac_link(ga_ls8c_ard_3_message):
-#     metadata, uri = get_metadata_uri(ga_ls8c_ard_3_message, stac_transform, None)
-#     assert uri != "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/" \
-#                   "analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/" \
-#                   "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
-#     assert uri == "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/" \
-#                   "analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/" \
-#                   "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
-#
-#
-# def test_transform(ga_ls8c_ard_3_message, ga_ls8c_ard_3_yaml):
-#     actual_doc, uri = get_metadata_uri(ga_ls8c_ard_3_message, stac_transform, None)
-#
-#     assert ga_ls8c_ard_3_yaml['id'] == actual_doc['id']
-#     assert ga_ls8c_ard_3_yaml['crs'] == actual_doc['crs']
-#     assert ga_ls8c_ard_3_yaml['product']['name'] == actual_doc['product']['name']
-#     assert ga_ls8c_ard_3_yaml['label'] == actual_doc['label']
-#
-#     # Test geometry field
-#     doc_diff = deep_diff(ga_ls8c_ard_3_yaml['geometry'], actual_doc['geometry'])
-#     assert doc_diff == {}, pformat(doc_diff)
-#
-#     # Test grids field
-#     doc_diff = deep_diff(ga_ls8c_ard_3_yaml['grids'], actual_doc['grids'])
-#     assert doc_diff == {}, pformat(doc_diff)
-#
-#     # Test measurements field
-#     doc_diff = deep_diff(ga_ls8c_ard_3_yaml['measurements'], actual_doc['measurements'])
-#     assert doc_diff == {}, pformat(doc_diff)
-#
-#     # Test properties field
-#     doc_diff = deep_diff(ga_ls8c_ard_3_yaml['properties'], actual_doc['properties'],
-#                          exclude_paths=["root['odc:product']",
-#                                         "root['datetime']",
-#                                         "root['dtr:start_datetime']",
-#                                         "root['dtr:end_datetime']",
-#                                         "root['odc:processing_datetime']",
-#                                         "root['proj:epsg']",
-#                                         "root['proj:shape']",
-#                                         "root['proj:transform']"]
-#                          )
-#     assert doc_diff == {}, pformat(doc_diff)
-#
-#     # Test all fields
-#     # doc_diff = deep_diff(ga_ls8c_ard_3_yaml, actual_doc)
-#     # assert doc_diff == {}, pformat(doc_diff)
+def test_stac_link(ga_ls8c_ard_3_message):
+    metadata, uri = get_metadata_uri(ga_ls8c_ard_3_message, stac_transform, None)
+    assert (
+        uri != "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/"
+        "analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/"
+        "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
+    )
+    assert (
+        uri == "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/"
+        "analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/"
+        "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
+    )
+
+
+def test_transform(ga_ls8c_ard_3_message, ga_ls8c_ard_3_yaml):
+    actual_doc, uri = get_metadata_uri(ga_ls8c_ard_3_message, stac_transform, None)
+
+    assert ga_ls8c_ard_3_yaml["id"] == actual_doc["id"]
+    assert ga_ls8c_ard_3_yaml["crs"] == actual_doc["crs"]
+    assert ga_ls8c_ard_3_yaml["product"]["name"] == actual_doc["product"]["name"]
+    assert ga_ls8c_ard_3_yaml["label"] == actual_doc["label"]
+
+    # Test geometry field
+    doc_diff = deep_diff(ga_ls8c_ard_3_yaml["geometry"], actual_doc["geometry"])
+    assert doc_diff == {}, pformat(doc_diff)
+
+    # Test grids field
+    doc_diff = deep_diff(ga_ls8c_ard_3_yaml["grids"], actual_doc["grids"])
+    assert doc_diff == {}, pformat(doc_diff)
+
+    # Test measurements field
+    doc_diff = deep_diff(ga_ls8c_ard_3_yaml["measurements"], actual_doc["measurements"])
+    assert doc_diff == {}, pformat(doc_diff)
+
+    # Test properties field
+    doc_diff = deep_diff(
+        ga_ls8c_ard_3_yaml["properties"],
+        actual_doc["properties"],
+        exclude_paths=[
+            "root['odc:product']",
+            "root['datetime']",
+            "root['dtr:start_datetime']",
+            "root['dtr:end_datetime']",
+            "root['odc:processing_datetime']",
+            "root['proj:epsg']",
+            "root['proj:shape']",
+            "root['proj:transform']",
+        ],
+    )
+    assert doc_diff == {}, pformat(doc_diff)
 
 
 @pytest.fixture


### PR DESCRIPTION
- Earlier test for stac transform were disabled due to dependency on new version of `odc_index`. 
- Enabling tests with the release of `odc-index`.